### PR TITLE
Update SAMtools module name for UNITY

### DIFF
--- a/slurm_example_scripts/05_setup2.slurm
+++ b/slurm_example_scripts/05_setup2.slurm
@@ -16,7 +16,7 @@ module purge
 #CHANGE THIS IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
 module load bbmap/38.63
-module load samtools/1.14
+module load bio/SAMtools/1.14-GCC-11.2.0
 module load bio/Bowtie2/2.4.5-GCC-11.3.0
 
 P=$SLURM_JOB_CPUS_PER_NODE

--- a/slurm_example_scripts/06_align.slurm
+++ b/slurm_example_scripts/06_align.slurm
@@ -13,7 +13,7 @@ module purge
 
 #CHANGE THIS IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
-module load samtools/1.14
+module load bio/SAMtools/1.14-GCC-11.2.0
 module load bio/Bowtie2/2.4.5-GCC-11.3.0
 
 PROCESSORS=$SLURM_JOB_CPUS_PER_NODE

--- a/slurm_example_scripts/06_align_array.slurm
+++ b/slurm_example_scripts/06_align_array.slurm
@@ -19,7 +19,7 @@ module purge
 
 #CHANGE THIS IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
-module load samtools/1.14
+module load bio/SAMtools/1.14-GCC-11.2.0
 module load bio/Bowtie2/2.4.5-GCC-11.3.0
 
 PROCESSORS=$SLURM_JOB_CPUS_PER_NODE

--- a/slurm_example_scripts/07_pileup.slurm
+++ b/slurm_example_scripts/07_pileup.slurm
@@ -15,7 +15,7 @@ module purge
 
 #CHANGE IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
-module load samtools/1.14
+module load bio/SAMtools/1.14-GCC-11.2.0
 
 OUTFOLDER=../../SISRS_Small_test #CHANGE to analysis directory
 

--- a/slurm_example_scripts/07_pileup_array.slurm
+++ b/slurm_example_scripts/07_pileup_array.slurm
@@ -18,7 +18,7 @@ module purge
 
 #CHANGE IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
-module load samtools/1.14
+module load bio/SAMtools/1.14-GCC-11.2.0
 
 OUTFOLDER=../../SISRS_Small_test #CHANGE to analysis directory
 

--- a/slurm_example_scripts/08_align2.slurm
+++ b/slurm_example_scripts/08_align2.slurm
@@ -15,7 +15,7 @@ module purge
 
 #CHANGE THIS IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
-module load samtools/1.14
+module load bio/SAMtools/1.14-GCC-11.2.0
 module load bio/Bowtie2/2.4.5-GCC-11.3.0
 
 PROCESSORS=$SLURM_JOB_CPUS_PER_NODE

--- a/slurm_example_scripts/08_align2_array.slurm
+++ b/slurm_example_scripts/08_align2_array.slurm
@@ -18,7 +18,7 @@ module purge
 
 #CHANGE THIS IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
-module load samtools/1.14
+module load bio/SAMtools/1.14-GCC-11.2.0
 module load bio/Bowtie2/2.4.5-GCC-11.3.0
 
 PROCESSORS=$SLURM_JOB_CPUS_PER_NODE

--- a/slurm_example_scripts/09_pileup2.slurm
+++ b/slurm_example_scripts/09_pileup2.slurm
@@ -15,7 +15,7 @@ module purge
 
 #CHANGE IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
-module load samtools/1.14
+module load bio/SAMtools/1.14-GCC-11.2.0
 
 OUTFOLDER=../../SISRS_Small_test #CHANGE to analysis directory
 MINREAD=3 #CHANGE to set the threshold for the number of reads to call a site

--- a/slurm_example_scripts/09_pileup2_array.slurm
+++ b/slurm_example_scripts/09_pileup2_array.slurm
@@ -18,7 +18,7 @@ module purge
 
 #CHANGE IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
-module load samtools/1.14
+module load bio/SAMtools/1.14-GCC-11.2.0
 
 OUTFOLDER=../../SISRS_Small_test #CHANGE to analysis directory
 MINREAD=3 #CHANGE to set the threshold for the number of reads to call a site


### PR DESCRIPTION
Updated SAMtools module name from samtools/1.14 to bio/SAMtools/1.14-G…CC-11.2.0 in all slurm_example_scripts for UNITY branch