### PR TITLE
Update bbmap module name from bbmap/38.63 to bbmap/39.01

### DIFF
--- a/slurm_example_scripts/02_trimmer.slurm
+++ b/slurm_example_scripts/02_trimmer.slurm
@@ -16,7 +16,7 @@ module purge
 #CHANGE THIS IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
 module load FastQC/0.11.9-Java-11
-module load bbmap/38.63
+module load bbmap/39.01
 
 P=$SLURM_JOB_CPUS_PER_NODE
 

--- a/slurm_example_scripts/03_subset.slurm
+++ b/slurm_example_scripts/03_subset.slurm
@@ -16,7 +16,7 @@ module purge
 #CHANGE THIS IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
 module load FastQC/0.11.9-Java-11
-module load bbmap/38.63
+module load bbmap/39.01
 
 GENOME=1000000000 #CHANGE THIS to the approximate size of your genome
 DIR=../../SISRS_Small_test #CHANGE this to your analysis folder

--- a/slurm_example_scripts/05_setup2.slurm
+++ b/slurm_example_scripts/05_setup2.slurm
@@ -15,7 +15,7 @@ module purge
 
 #CHANGE THIS IF NOT ON UNITY
 module load uri/main bio/Biopython/1.79-intel-2022a
-module load bbmap/38.63
+module load bbmap/39.01
 module load bio/SAMtools/1.14-GCC-11.2.0
 module load bio/Bowtie2/2.4.5-GCC-11.3.0
 


### PR DESCRIPTION
Update bbmap module name from bbmap/38.63 to bbmap/39.01 in all slurm_example_scripts for UNITY branch